### PR TITLE
Purge AWS Xray (gm-worker)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 boto3==1.9.96
 requests==2.21.0
-aws-xray-sdk==2.4.3

--- a/worker.py
+++ b/worker.py
@@ -2,18 +2,9 @@ import argparse
 import sys
 import logging
 
-from aws_xray_sdk.core import xray_recorder, patch
-
 from gm.worker import Worker
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
-
-xray_recorder.configure(
-    service='GazetteMachineWorker',
-    sampling=False,
-    plugins=('ECSPlugin',),
-)
-patch(['requests'])
 
 
 if __name__ == '__main__':
@@ -27,8 +18,6 @@ if __name__ == '__main__':
 
     if args.ocr:
         # TODO: inject root and parent trace ids
-        with xray_recorder.in_segment():
-            with xray_recorder.in_subsegment('ocr'):
-                gm.ocr_and_update(args.info_path)
+        gm.ocr_and_update(args.info_path)
     else:
         parser.print_help()

--- a/worker.py
+++ b/worker.py
@@ -17,7 +17,6 @@ if __name__ == '__main__':
     info = None
 
     if args.ocr:
-        # TODO: inject root and parent trace ids
         gm.ocr_and_update(args.info_path)
     else:
         parser.print_help()


### PR DESCRIPTION
This PR removes AWS Xray integration from gm-worker

closes [#42](https://github.com/laws-africa/gazettemachine/issues/42)